### PR TITLE
Refactored Xamarin Forms sample page loading

### DIFF
--- a/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/ViewModels/ActionPlanDetailsViewModel.cs
+++ b/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/ViewModels/ActionPlanDetailsViewModel.cs
@@ -38,11 +38,9 @@ namespace HealthVault.Sample.Xamarin.Core.ViewModels
                 var xpath = task.TrackingPolicy.TargetEvents.FirstOrDefault().ElementXPath;
                 if (xpath.Contains("thing/data-xml/weight"))
                 {
-                    PersonInfo personInfo = await this.connection.GetPersonInfoAsync();
-
                     var weightAddPage = new WeightAddPage
                     {
-                        BindingContext = new WeightAddViewModel(this.connection.CreateThingClient(), personInfo.SelectedRecord.Id, this.NavigationService),
+                        BindingContext = new WeightAddViewModel(this.connection, this.NavigationService),
                     };
                     await this.NavigationService.NavigateAsync(weightAddPage);
                 }

--- a/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/ViewModels/MedicationsMainViewModel.cs
+++ b/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/ViewModels/MedicationsMainViewModel.cs
@@ -4,11 +4,14 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using HealthVault.Sample.Xamarin.Core.Models;
 using HealthVault.Sample.Xamarin.Core.Services;
 using HealthVault.Sample.Xamarin.Core.ViewModels.ViewRows;
 using HealthVault.Sample.Xamarin.Core.Views;
 using Microsoft.HealthVault.Clients;
+using Microsoft.HealthVault.Connection;
 using Microsoft.HealthVault.ItemTypes;
+using Microsoft.HealthVault.Record;
 using Microsoft.HealthVault.Vocabulary;
 using Xamarin.Forms;
 
@@ -16,26 +19,34 @@ namespace HealthVault.Sample.Xamarin.Core.ViewModels
 {
     public class MedicationsMainViewModel : ViewModel
     {
-        private readonly IList<VocabularyItem> ingredientChoices;
-        private readonly IThingClient thingClient;
-        private readonly Guid recordId;
+        private readonly IHealthVaultConnection connection;
+
         private ObservableCollection<MedicationsSummaryViewRow> currentMedications;
         private ObservableCollection<MedicationsSummaryViewRow> pastMedications;
 
         public MedicationsMainViewModel(
-            IEnumerable<Medication> items, 
-            IList<VocabularyItem> ingredientChoices,
-            IThingClient thingClient,
-            Guid recordId,
+            IHealthVaultConnection connection,
             INavigationService navigationService) : base(navigationService)
         {
-            this.ingredientChoices = ingredientChoices;
-            this.thingClient = thingClient;
-            this.recordId = recordId;
+            this.connection = connection;
 
             this.ItemSelectedCommand = new Command<MedicationsSummaryViewRow>(async o => await this.GoToMedicationsSummaryPageAsync(o.Medication));
 
-            this.UpdateDisplay(items);
+            this.LoadState = LoadState.Loading;
+        }
+
+        public override async Task OnNavigateToAsync()
+        {
+            await this.LoadAsync(async () =>
+            {
+                var person = await this.connection.GetPersonInfoAsync();
+                IThingClient thingClient = this.connection.CreateThingClient();
+                HealthRecordInfo record = person.SelectedRecord;
+                IReadOnlyCollection<Medication> items = await thingClient.GetThingsAsync<Medication>(record.Id);
+                this.UpdateDisplay(items);
+
+                await base.OnNavigateToAsync();
+            });
         }
 
         public ObservableCollection<MedicationsSummaryViewRow> CurrentMedications
@@ -64,7 +75,10 @@ namespace HealthVault.Sample.Xamarin.Core.ViewModels
 
         public override async Task OnNavigateBackAsync()
         {
-            IReadOnlyCollection<Medication> items = await this.thingClient.GetThingsAsync<Medication>(this.recordId);
+            var person = await this.connection.GetPersonInfoAsync();
+            IThingClient thingClient = this.connection.CreateThingClient();
+            HealthRecordInfo record = person.SelectedRecord;
+            IReadOnlyCollection<Medication> items = await thingClient.GetThingsAsync<Medication>(record.Id);
             this.UpdateDisplay(items);
             await base.OnNavigateBackAsync();
         }
@@ -98,7 +112,7 @@ namespace HealthVault.Sample.Xamarin.Core.ViewModels
         {
             var medicationsMainPage = new MedicationsSummaryPage()
             {
-                BindingContext = new MedicationsSummaryViewModel(medication, this.ingredientChoices, this.thingClient, this.recordId, this.NavigationService),
+                BindingContext = new MedicationsSummaryViewModel(medication, this.connection, this.NavigationService),
             };
             await this.NavigationService.NavigateAsync(medicationsMainPage);
         }

--- a/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/Views/MedicationEditPage.xaml
+++ b/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/Views/MedicationEditPage.xaml
@@ -2,101 +2,112 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:core="clr-namespace:HealthVault.Sample.Xamarin.Core;assembly=HealthVault.Sample.Xamarin.Core"
+             xmlns:models="clr-namespace:HealthVault.Sample.Xamarin.Core.Models;assembly=HealthVault.Sample.Xamarin.Core"
              x:Class="HealthVault.Sample.Xamarin.Core.Views.MedicationEditPage" 
              Title="{x:Static core:StringResource.EditMedicationPageTitle}">
-    <Grid Padding="10" BackgroundColor="{StaticResource LightPageBackground}">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="2*" />
-            <ColumnDefinition Width="2*" />
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="20"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="20"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="20"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="20"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="20"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <Label 
-            Grid.Row="0"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            Text="{x:Static core:StringResource.Name}" 
-            VerticalTextAlignment="Start" />
-        <Picker
-            Grid.Row="1"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            ItemsSource="{Binding IngredientChoices}"
-            ItemDisplayBinding="{Binding DisplayText}"
-            SelectedItem="{Binding Name}"/>
-        <Label 
-            Grid.Row="2"
-            Grid.Column="0"
-            Text="{x:Static core:StringResource.DosageType}" 
-            VerticalTextAlignment="Start" />
-        <Label 
-            Grid.Row="2"
-            Grid.Column="1"
-            Text="{x:Static core:StringResource.Strength}" 
-            VerticalTextAlignment="Start" />
-        <Entry 
-            Grid.Row="3"
-            Grid.Column="0"
-            Text="{Binding DosageType}" />
-        <Entry 
-            Grid.Row="3"
-            Grid.Column="1"
-            Text="{Binding Strength}" />
-        <Label 
-            Grid.Row="4"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            Text="{x:Static core:StringResource.TreatmentProvider}" 
-            VerticalTextAlignment="Start" />
-        <Entry 
-            Grid.Row="5"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            Text="{Binding TreatmentProvider}" />
-        <Label 
-            Grid.Row="6"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            Text="{x:Static core:StringResource.ReasonForTaking}" 
-            VerticalTextAlignment="Start" />
-        <Entry 
-            Grid.Row="7"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            Text="{Binding ReasonForTaking}" />
-        <Label 
-            Grid.Row="8"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            Text="{x:Static core:StringResource.DateStarted}" 
-            VerticalTextAlignment="Start" />
-        <DatePicker  
-            Grid.Row="9"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            Date="{Binding DateStarted}"
-            HorizontalOptions="Start">
-            <DatePicker.Format>yyyy-MM-dd</DatePicker.Format>
-        </DatePicker>
-        <Button 
-            Grid.Row="10"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            Margin="0,15,0,0"
-            Command="{Binding SaveCommand}"
-            TextColor="White"
-            BackgroundColor="{StaticResource HighlightColor}"
-            Text="{x:Static core:StringResource.Save}" />
+    <Grid BackgroundColor="{StaticResource LightPageBackground}">
+        <Grid Padding="10" IsVisible="{Binding LoadState, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static models:LoadState.Loaded}}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="2*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="20"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="20"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="20"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="20"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="20"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Label 
+                Grid.Row="0"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Text="{x:Static core:StringResource.Name}" 
+                VerticalTextAlignment="Start" />
+            <Picker
+                Grid.Row="1"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                ItemsSource="{Binding IngredientChoices}"
+                ItemDisplayBinding="{Binding DisplayText}"
+                SelectedItem="{Binding Name}"/>
+            <Label 
+                Grid.Row="2"
+                Grid.Column="0"
+                Text="{x:Static core:StringResource.DosageType}" 
+                VerticalTextAlignment="Start" />
+            <Label 
+                Grid.Row="2"
+                Grid.Column="1"
+                Text="{x:Static core:StringResource.Strength}" 
+                VerticalTextAlignment="Start" />
+            <Entry 
+                Grid.Row="3"
+                Grid.Column="0"
+                Text="{Binding DosageType}" />
+            <Entry 
+                Grid.Row="3"
+                Grid.Column="1"
+                Text="{Binding Strength}" />
+            <Label 
+                Grid.Row="4"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Text="{x:Static core:StringResource.TreatmentProvider}" 
+                VerticalTextAlignment="Start" />
+            <Entry 
+                Grid.Row="5"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Text="{Binding TreatmentProvider}" />
+            <Label 
+                Grid.Row="6"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Text="{x:Static core:StringResource.ReasonForTaking}" 
+                VerticalTextAlignment="Start" />
+            <Entry 
+                Grid.Row="7"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Text="{Binding ReasonForTaking}" />
+            <Label 
+                Grid.Row="8"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Text="{x:Static core:StringResource.DateStarted}" 
+                VerticalTextAlignment="Start" />
+            <DatePicker  
+                Grid.Row="9"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Date="{Binding DateStarted}"
+                HorizontalOptions="Start">
+                <DatePicker.Format>yyyy-MM-dd</DatePicker.Format>
+            </DatePicker>
+            <Button 
+                Grid.Row="10"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Margin="0,15,0,0"
+                Command="{Binding SaveCommand}"
+                TextColor="White"
+                BackgroundColor="{StaticResource HighlightColor}"
+                Text="{x:Static core:StringResource.Save}" />
+        </Grid>
+
+        <ActivityIndicator 
+            Style="{StaticResource PageLoadingIndicator}"
+            IsVisible="{Binding LoadState, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static models:LoadState.Loading}}" />
+        <Label
+            Text="{Binding ErrorText}"
+            IsVisible="{Binding LoadState, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static models:LoadState.Error}}"
+            Style="{StaticResource ErrorLabel}" />
     </Grid>
 </ContentPage>

--- a/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/Views/MedicationsMainPage.xaml
+++ b/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/Views/MedicationsMainPage.xaml
@@ -5,6 +5,7 @@
     xmlns:behaviors="clr-namespace:HealthVault.Sample.Xamarin.Core.Behaviors;assembly=HealthVault.Sample.Xamarin.Core"
     xmlns:markup="clr-namespace:HealthVault.Sample.Xamarin.Core.MarkupExtensions;assembly=HealthVault.Sample.Xamarin.Core"
     xmlns:core="clr-namespace:HealthVault.Sample.Xamarin.Core;assembly=HealthVault.Sample.Xamarin.Core"
+    xmlns:models="clr-namespace:HealthVault.Sample.Xamarin.Core.Models;assembly=HealthVault.Sample.Xamarin.Core"
     x:Class="HealthVault.Sample.Xamarin.Core.Views.MedicationsMainPage"
     Title="{x:Static core:StringResource.MedicationsPageTitle}">
     <ContentPage.Resources>
@@ -50,30 +51,42 @@
             </Style>
         </ResourceDictionary>
     </ContentPage.Resources>
-    <StackLayout BackgroundColor="{StaticResource PageBackground}">
-        <Label 
-            Text="{x:Static core:StringResource.CurrentMedicationsSection}"
-            Style="{StaticResource SectionHeader}" />
-        <ListView 
-            ItemsSource="{Binding CurrentMedications}" 
-            BackgroundColor="{StaticResource PageBackground}"
-            HasUnevenRows="true"
-            ItemTemplate="{StaticResource MedicationItemTemplate}">
-            <ListView.Behaviors>
-                <behaviors:EventToCommandBehavior EventName="ItemTapped" Command="{Binding ItemSelectedCommand}" Converter="{StaticResource TappedItemConverter}" />
-            </ListView.Behaviors>
-        </ListView>
-        <Label 
-            Text="{x:Static core:StringResource.PastMedicationsSection}"
-            Style="{StaticResource SectionHeader}" />
-        <ListView 
-            ItemsSource="{Binding PastMedications}"
-            BackgroundColor="{StaticResource PageBackground}"
-            HasUnevenRows="true"
-            ItemTemplate="{StaticResource MedicationItemTemplate}">
-            <ListView.Behaviors>
-                <behaviors:EventToCommandBehavior EventName="ItemTapped" Command="{Binding ItemSelectedCommand}" Converter="{StaticResource TappedItemConverter}" />
-            </ListView.Behaviors>
-        </ListView>
-    </StackLayout>
+    <Grid>
+        <StackLayout
+            BackgroundColor="{StaticResource PageBackground}" 
+            IsVisible="{Binding LoadState, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static models:LoadState.Loaded}}">
+            <Label 
+                Text="{x:Static core:StringResource.CurrentMedicationsSection}"
+                Style="{StaticResource SectionHeader}" />
+            <ListView 
+                ItemsSource="{Binding CurrentMedications}" 
+                BackgroundColor="{StaticResource PageBackground}"
+                HasUnevenRows="true"
+                ItemTemplate="{StaticResource MedicationItemTemplate}">
+                <ListView.Behaviors>
+                    <behaviors:EventToCommandBehavior EventName="ItemTapped" Command="{Binding ItemSelectedCommand}" Converter="{StaticResource TappedItemConverter}" />
+                </ListView.Behaviors>
+            </ListView>
+            <Label 
+                Text="{x:Static core:StringResource.PastMedicationsSection}"
+                Style="{StaticResource SectionHeader}" />
+            <ListView 
+                ItemsSource="{Binding PastMedications}"
+                BackgroundColor="{StaticResource PageBackground}"
+                HasUnevenRows="true"
+                ItemTemplate="{StaticResource MedicationItemTemplate}">
+                <ListView.Behaviors>
+                    <behaviors:EventToCommandBehavior EventName="ItemTapped" Command="{Binding ItemSelectedCommand}" Converter="{StaticResource TappedItemConverter}" />
+                </ListView.Behaviors>
+            </ListView>
+        </StackLayout>
+        <ActivityIndicator 
+            Style="{StaticResource PageLoadingIndicator}"
+            IsVisible="{Binding LoadState, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static models:LoadState.Loading}}" />
+        <Label
+            Text="{Binding ErrorText}"
+            IsVisible="{Binding LoadState, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static models:LoadState.Error}}"
+            Style="{StaticResource ErrorLabel}" />
+    </Grid>
+
 </ContentPage>

--- a/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/Views/ProfilePage.xaml
+++ b/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/Views/ProfilePage.xaml
@@ -6,8 +6,10 @@
     xmlns:models="clr-namespace:HealthVault.Sample.Xamarin.Core.Models;assembly=HealthVault.Sample.Xamarin.Core"
     x:Class="HealthVault.Sample.Xamarin.Core.Views.ProfilePage" 
     Title="{x:Static core:StringResource.ProfilePageTitle}">
-    <Frame BackgroundColor="{StaticResource LightPageBackground}" Padding="10">
-        <Grid>
+    <Grid BackgroundColor="{StaticResource LightPageBackground}">
+        <Grid 
+            Padding="10"
+            IsVisible="{Binding LoadState, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static models:LoadState.Loaded}}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="2*" />
                 <ColumnDefinition Width="2*" />
@@ -92,18 +94,17 @@
                 Grid.Column="0"
                 Grid.ColumnSpan="2"
                 Margin="0,16,0,0"
-                IsVisible="{Binding LoadState, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static models:LoadState.Loaded}}"
                 Command="{Binding SaveCommand}"
                 Text="{x:Static core:StringResource.Save}"
                 Style="{StaticResource StandardButton}" />
-
-            <ActivityIndicator 
-                Grid.Row="7"
-                Grid.Column="0"
-                Grid.ColumnSpan="2"
-                Margin="0,20,0,0"
-                Style="{StaticResource PageLoadingIndicator}" 
-                IsVisible="{Binding LoadState, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static models:LoadState.Loading}}" />
         </Grid>
-    </Frame>
+
+        <ActivityIndicator 
+            Style="{StaticResource PageLoadingIndicator}" 
+            IsVisible="{Binding LoadState, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static models:LoadState.Loading}}" />
+        <Label
+            Text="{Binding ErrorText}"
+            IsVisible="{Binding LoadState, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static models:LoadState.Error}}"
+            Style="{StaticResource ErrorLabel}" />
+    </Grid>
 </ContentPage>


### PR DESCRIPTION
* Changed pages to pass through just the IHealthVaultConnection, reducing the amount of data needed to daisy-chain over to other viewmodels
* Moved data loading to on the viewmodel itself, which will keep the code that loads the data on the page where it's used. This should make the sample easier to follow.