### PR TITLE
Updating sample to work with prerelease nuget

### DIFF
--- a/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Android/packages.config
+++ b/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Android/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ExifLib.PCL" version="1.0.2-pre01" targetFramework="monoandroid71" />
   <package id="Grace" version="6.0.1" targetFramework="monoandroid70" />
@@ -6,7 +6,7 @@
   <package id="Microsoft.HealthVault" version="1.66.20706.2-preview" targetFramework="monoandroid71" />
   <package id="Microsoft.HealthVault.Client" version="1.66.20706.2-preview" targetFramework="monoandroid71" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="monoandroid70" />
-  <package id="Microsoft.Rest.ClientRuntime" version="2.3.7" targetFramework="monoandroid71" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.8" targetFramework="monoandroid71" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="monoandroid70" />
   <package id="modernhttpclient" version="2.4.2" targetFramework="monoandroid70" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="monoandroid70" />
@@ -40,6 +40,7 @@
   <package id="System.Reflection" version="4.3.0" targetFramework="monoandroid70" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="monoandroid70" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="monoandroid70" />
+  <package id="System.Reflection.TypeExtensions" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="monoandroid70" />
   <package id="System.Runtime" version="4.3.0" targetFramework="monoandroid70" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="monoandroid70" />

--- a/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Android/packages.config
+++ b/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Android/packages.config
@@ -3,8 +3,8 @@
   <package id="ExifLib.PCL" version="1.0.2-pre01" targetFramework="monoandroid71" />
   <package id="Grace" version="6.0.1" targetFramework="monoandroid70" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="monoandroid70" />
-  <package id="Microsoft.HealthVault" version="1.0.20605.1" targetFramework="monoandroid71" />
-  <package id="Microsoft.HealthVault.Client" version="1.0.20605.1" targetFramework="monoandroid71" />
+  <package id="Microsoft.HealthVault" version="1.66.20706.2-preview" targetFramework="monoandroid71" />
+  <package id="Microsoft.HealthVault.Client" version="1.66.20706.2-preview" targetFramework="monoandroid71" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="monoandroid70" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.7" targetFramework="monoandroid71" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="monoandroid70" />

--- a/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/ViewModels/ActionPlanDetailsViewModel.cs
+++ b/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/ViewModels/ActionPlanDetailsViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -14,20 +14,20 @@ namespace HealthVault.Sample.Xamarin.Core.ViewModels
     {
         private readonly IHealthVaultSodaConnection _connection;
 
-        public ActionPlanDetailsViewModel(ActionPlanInstance actionPlanInstance, IHealthVaultSodaConnection connection, INavigationService navigationService)
+        public ActionPlanDetailsViewModel(ActionPlanInstanceV2 actionPlanInstance, IHealthVaultSodaConnection connection, INavigationService navigationService)
             : base(navigationService)
         {
             _connection = connection;
-            ItemSelectedCommand = new Command<ActionPlanTaskInstance>(async o => await HandleTaskSelectedAsync(o));
+            ItemSelectedCommand = new Command<ActionPlanTaskInstanceV2>(async o => await HandleTaskSelectedAsync(o));
 
             Plan = actionPlanInstance;
         }
 
         public ICommand ItemSelectedCommand { get; }
 
-        public ActionPlanInstance Plan { get; }
+        public ActionPlanInstanceV2 Plan { get; }
 
-        private async Task HandleTaskSelectedAsync(ActionPlanTaskInstance task)
+        private async Task HandleTaskSelectedAsync(ActionPlanTaskInstanceV2 task)
         {
             if (task.TrackingPolicy.IsAutoTrackable == true)
             {

--- a/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/ViewModels/ActionPlansViewModel.cs
+++ b/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/ViewModels/ActionPlansViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,12 +25,12 @@ namespace HealthVault.Sample.Xamarin.Core.ViewModels
         {
             _connection = connection;
 
-            ItemSelectedCommand = new Command<ActionPlanInstance>(async o => await GoToActionPlanDetailsPageAsync(o));
+            ItemSelectedCommand = new Command<ActionPlanInstanceV2>(async o => await GoToActionPlanDetailsPageAsync(o));
         }
 
-        private IEnumerable<ActionPlanInstance> _plans;
+        private IEnumerable<ActionPlanInstanceV2> _plans;
 
-        public IEnumerable<ActionPlanInstance> Plans
+        public IEnumerable<ActionPlanInstanceV2> Plans
         {
             get { return _plans; }
 
@@ -50,7 +50,7 @@ namespace HealthVault.Sample.Xamarin.Core.ViewModels
                 PersonInfo personInfo = await _connection.GetPersonInfoAsync();
 
                 IMicrosoftHealthVaultRestApi restApi = _connection.CreateMicrosoftHealthVaultRestApi(personInfo.SelectedRecord.Id);
-                var response = await restApi.GetActionPlansAsync();
+                var response = await restApi.ActionPlans.GetAsync();
 
                 Plans = response.Plans.Where(p => p.Status == "Recommended" || p.Status == "InProgress");
 
@@ -58,7 +58,7 @@ namespace HealthVault.Sample.Xamarin.Core.ViewModels
             });
         }
 
-        private async Task GoToActionPlanDetailsPageAsync(ActionPlanInstance actionPlan)
+        private async Task GoToActionPlanDetailsPageAsync(ActionPlanInstanceV2 actionPlan)
         {
             var actionPlanDetailsPage = new ActionPlanDetailsPage
             {

--- a/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/project.json
+++ b/dotNETStandard/HealthVault.Mobile/cs/Xamarin.Core/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "Microsoft.HealthVault.Client": "1.0.20605.1",
+    "Microsoft.HealthVault.Client": "1.66.20706.2-preview",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "NETStandard.Library": "1.6.1",
     "Newtonsoft.Json": "10.0.2",

--- a/dotNETStandard/HealthVault.Mobile/cs/Xamarin.UWP/project.json
+++ b/dotNETStandard/HealthVault.Mobile/cs/Xamarin.UWP/project.json
@@ -1,6 +1,6 @@
-﻿{
+{
   "dependencies": {
-    "Microsoft.HealthVault.Client": "1.0.20605.1",
+    "Microsoft.HealthVault.Client": "1.66.20706.2-preview",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.3.3",
     "Newtonsoft.Json": "10.0.2",
     "Xamarin.Forms": "2.3.4.224",

--- a/dotNETStandard/HealthVault.Mobile/cs/Xamarin.iOS/packages.config
+++ b/dotNETStandard/HealthVault.Mobile/cs/Xamarin.iOS/packages.config
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ExifLib.PCL" version="1.0.2-pre01" targetFramework="xamarinios10" />
   <package id="Grace" version="6.0.1" targetFramework="xamarinios10" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="Microsoft.HealthVault" version="1.0.20605.1" targetFramework="xamarinios10" />
-  <package id="Microsoft.HealthVault.Client" version="1.0.20605.1" targetFramework="xamarinios10" />
+  <package id="Microsoft.HealthVault" version="1.66.20706.2-preview" targetFramework="xamarinios10" />
+  <package id="Microsoft.HealthVault.Client" version="1.66.20706.2-preview" targetFramework="xamarinios10" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="xamarinios10" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.7" targetFramework="xamarinios10" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="xamarinios10" />


### PR DESCRIPTION
The sample uses a nuget from the nightly store that is not available to regular users, thus the change of version, not the nuget source though...btw, where is the ActionPlanInstanceV2 in the application configuration center for regular users and SODA apps? I had to change the ActionPlanInstance to V2 since it's been deprecated to build, but can't find it to set the access rule in my ACC? TIA
--


