### PR TITLE
Add tracking policy override to tracking validation

### DIFF
--- a/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/Controllers/ActionPlanController.cs
+++ b/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/Controllers/ActionPlanController.cs
@@ -218,13 +218,10 @@ namespace HealthVaultProviderManagementPortal.Controllers
         /// Get a task for a user.
         /// </summary>
         [HttpGet]
-        public ActionResult ValidateTracking(Guid id, Guid planId, Guid personId, Guid recordId)
+        public async Task<ActionResult> ValidateTracking(Guid id, Guid planId, Guid personId, Guid recordId)
         {
-            return View("TrackingValidationEntry", new ActionPlanTaskInstance()
-            {
-                Id = id.ToString(),
-                AssociatedPlanId = planId.ToString()
-            });
+            var response = await ExecuteMicrosoftHealthVaultRestApiAsync(api => api.ActionPlanTasks.GetByIdAsync(id.ToString()), personId, recordId);
+            return View("TrackingValidationEntry", response);
         }
 
         /// <summary>

--- a/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/Controllers/ActionPlanController.cs
+++ b/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/Controllers/ActionPlanController.cs
@@ -233,10 +233,15 @@ namespace HealthVaultProviderManagementPortal.Controllers
         [HttpPost]
         [ValidateInput(false)]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult> ValidateTracking(Guid id, string thing, Guid personId, Guid recordId)
+        public async Task<ActionResult> ValidateTracking(Guid id, string trackingPolicy, string thing, Guid personId, Guid recordId)
         {
             var restApi = await CreateMicrosoftHealthVaultRestApiAsync(personId, recordId);
             var taskInstance = await restApi.ActionPlanTasks.GetByIdAsync(id.ToString());
+
+            if (!string.IsNullOrWhiteSpace(trackingPolicy))
+            {
+                taskInstance.TrackingPolicy = trackingPolicy.AsActionPlanTrackingPolicy();
+            }
 
             var trackingValidation = new TrackingValidation
             {

--- a/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/Helpers/TypeHelper.cs
+++ b/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/Helpers/TypeHelper.cs
@@ -17,5 +17,10 @@ namespace HealthVaultProviderManagementPortal.Helpers
         {
             return JsonConvert.DeserializeObject<ActionPlanTaskV2>(JsonConvert.SerializeObject(instance));
         }
+
+        public static ActionPlanTrackingPolicy AsActionPlanTrackingPolicy(this string instance)
+        {
+            return JsonConvert.DeserializeObject<ActionPlanTrackingPolicy>(instance);
+        }
     }
 }

--- a/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/Views/ActionPlan/TrackingValidationEntry.cshtml
+++ b/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/Views/ActionPlan/TrackingValidationEntry.cshtml
@@ -7,7 +7,8 @@
 
     THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *@
-@model Microsoft.HealthVault.RestApi.Generated.Models.ActionPlanTaskInstance
+@using Newtonsoft.Json
+@model Microsoft.HealthVault.RestApi.Generated.Models.ActionPlanTaskInstanceV2
 
 @{
     ViewBag.Title = "Validate Task Auto Tracking";
@@ -32,7 +33,7 @@
         <div class="form-group">
             <div class="col-md-12 slim-col">
                 @Html.Label("Tracking policy override JSON (optional)", htmlAttributes: new { @class = "control-label" })
-                @Html.TextArea("trackingPolicy", htmlAttributes: new { @class = "form-control", rows = 15 })
+                @Html.TextArea("trackingPolicy", JsonConvert.SerializeObject(Model.TrackingPolicy, Formatting.Indented), htmlAttributes: new { @class = "form-control", rows = 15 })
             </div>
         </div>
 

--- a/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/Views/ActionPlan/TrackingValidationEntry.cshtml
+++ b/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/Views/ActionPlan/TrackingValidationEntry.cshtml
@@ -28,10 +28,17 @@
                 @Html.EditorFor(model => model.Id, new { htmlAttributes = new { @class = "form-control", @readonly = true } })
             </div>
         </div>
+        
+        <div class="form-group">
+            <div class="col-md-12 slim-col">
+                @Html.Label("Tracking policy override JSON", htmlAttributes: new { @class = "control-label" })
+                @Html.TextArea("trackingPolicy", htmlAttributes: new { @class = "form-control", rows = 15 })
+            </div>
+        </div>
 
         <div class="form-group">
             <div class="col-md-12 slim-col">
-                @Html.Label("HealthVault thing", htmlAttributes: new { @class = "control-label" })
+                @Html.Label("HealthVault thing XML", htmlAttributes: new { @class = "control-label" })
                 @Html.TextArea("thing", htmlAttributes: new { @class = "form-control", rows = 25 })
             </div>
         </div>

--- a/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/Views/ActionPlan/TrackingValidationEntry.cshtml
+++ b/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/Views/ActionPlan/TrackingValidationEntry.cshtml
@@ -31,7 +31,7 @@
         
         <div class="form-group">
             <div class="col-md-12 slim-col">
-                @Html.Label("Tracking policy override JSON", htmlAttributes: new { @class = "control-label" })
+                @Html.Label("Tracking policy override JSON (optional)", htmlAttributes: new { @class = "control-label" })
                 @Html.TextArea("trackingPolicy", htmlAttributes: new { @class = "form-control", rows = 15 })
             </div>
         </div>


### PR DESCRIPTION
Update the Action Plan tracking validation page to include a place to paste in tracking policy to ease testing of auto tracking