### PR TITLE
Fix the reference to System.Runtime in the Provider sample

### DIFF
--- a/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal.csproj
+++ b/dotNETStandard/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal/HealthVaultProviderManagementPortal.csproj
@@ -153,7 +153,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime">
-      <HintPath>..\..\..\..\..\..\Repos\healthvault-samples\dotNETStandard\HealthVaultProviderManagementPortal\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>


### PR DESCRIPTION
The reference to System.Runtime used a system specific path. Fixed it so that it used the same path as other packages